### PR TITLE
Fix sap b1 issues

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+
+[*.cs]
+tab_width = 4
+trim_trailing_whitespace = true
+csharp_new_line_before_open_brace = all
+csharp_preserve_single_line_statements = true
+dotnet_sort_system_directives_first = true 

--- a/GXOData.Client.nuspec
+++ b/GXOData.Client.nuspec
@@ -3,7 +3,7 @@
   <metadata xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <id>GXOdata.Client</id>
     <authors>Vagif Abilov and GeneXus</authors>
-    <version>5.2.2.2</version>
+    <version>5.2.2.3</version>
     <owners>Vagif Abilov</owners>
     <description>
       GXOdata.Client is a multiplatform OData client library supporting .NET 4.x, .NET Standard, .NET Core, iOS and Android. The adapter provides a great alternative to WCF Data Services client. It does not require generation of context or entity classes and fits RESTful nature of OData services.

--- a/src/Simple.OData.Client.Core/Expressions/ODataExpression.Format.cs
+++ b/src/Simple.OData.Client.Core/Expressions/ODataExpression.Format.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
@@ -236,11 +236,11 @@ namespace Simple.OData.Client
             }
             else
             {
-				string uriLiteral = context.Session.Adapter.GetCommandFormatter().ConvertValueToUriLiteral(Value, false);
-				if (Value is DateTime &&
-					(context.Session.Settings.Properties?[ODataClientSettings.ExtraProperties.STRINGIZE_DATETIME_VALUES] as bool? == true))
-					return $"'{ uriLiteral }'";
-				return uriLiteral;
+                string uriLiteral = context.Session.Adapter.GetCommandFormatter().ConvertValueToUriLiteral(Value, false);
+                if (Value is DateTime &&
+                    (context.Session.Settings.Properties?[ODataClientSettings.ExtraProperties.STRINGIZE_DATETIME_VALUES] as bool? == true))
+                    return $"'{ uriLiteral }'";
+                return uriLiteral;
             }
         }
 

--- a/src/Simple.OData.Client.Core/Expressions/ODataExpression.Format.cs
+++ b/src/Simple.OData.Client.Core/Expressions/ODataExpression.Format.cs
@@ -236,7 +236,11 @@ namespace Simple.OData.Client
             }
             else
             {
-                return context.Session.Adapter.GetCommandFormatter().ConvertValueToUriLiteral(Value, false);
+				string uriLiteral = context.Session.Adapter.GetCommandFormatter().ConvertValueToUriLiteral(Value, false);
+				if (Value is DateTime &&
+					(context.Session.Settings.Properties?[ODataClientSettings.ExtraProperties.STRINGIZE_DATETIME_VALUES] as bool? == true))
+					return $"'{ uriLiteral }'";
+				return uriLiteral;
             }
         }
 

--- a/src/Simple.OData.Client.Core/ODataClientSettings.cs
+++ b/src/Simple.OData.Client.Core/ODataClientSettings.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -181,6 +182,14 @@ namespace Simple.OData.Client
         public ODataTrace TraceFilter { get; set; }
 
         /// <summary>
+        /// Gets or sets the extra properties dictionary.
+        /// </summary>
+        /// <value>
+        /// Dictionary with extra properties settings.
+        /// </value>
+		public Dictionary<string, object> Properties { get; set; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="ODataClientSettings"/> class.
         /// </summary>
         public ODataClientSettings()
@@ -231,6 +240,12 @@ namespace Simple.OData.Client
             this.AfterResponse = session.Settings.AfterResponse;
             this.OnTrace = session.Settings.OnTrace;
             this.TraceFilter = session.Settings.TraceFilter;
-        }
+			this.Properties = session.Settings.Properties == null ? null : new Dictionary<string, object>(session.Settings.Properties);
+		}
+
+		public class ExtraProperties
+		{
+			public const string STRINGIZE_DATETIME_VALUES = "StringizeDatetimeValues";
+		}
     }
 }

--- a/src/Simple.OData.Client.Core/ODataClientSettings.cs
+++ b/src/Simple.OData.Client.Core/ODataClientSettings.cs
@@ -187,7 +187,7 @@ namespace Simple.OData.Client
         /// <value>
         /// Dictionary with extra properties settings.
         /// </value>
-		public Dictionary<string, object> Properties { get; set; }
+        public Dictionary<string, object> Properties { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ODataClientSettings"/> class.
@@ -240,12 +240,12 @@ namespace Simple.OData.Client
             this.AfterResponse = session.Settings.AfterResponse;
             this.OnTrace = session.Settings.OnTrace;
             this.TraceFilter = session.Settings.TraceFilter;
-			this.Properties = session.Settings.Properties == null ? null : new Dictionary<string, object>(session.Settings.Properties);
-		}
+            this.Properties = session.Settings.Properties == null ? null : new Dictionary<string, object>(session.Settings.Properties);
+        }
 
-		public class ExtraProperties
-		{
-			public const string STRINGIZE_DATETIME_VALUES = "StringizeDatetimeValues";
-		}
+        public class ExtraProperties
+        {
+            public const string STRINGIZE_DATETIME_VALUES = "StringizeDatetimeValues";
+        }
     }
 }

--- a/src/Simple.OData.Client.V4.Adapter/CommandFormatter.cs
+++ b/src/Simple.OData.Client.V4.Adapter/CommandFormatter.cs
@@ -140,12 +140,14 @@ namespace Simple.OData.Client.V4.Adapter
             return text;
         }
 
+		private const char ODATA_V3_FORMATTING_ESCAPE_SEPARATOR = '~';
+
         private IList<string> SelectPathSegmentColumns(
             IList<string> columns, string path, IList<string> excludePaths = null)
         {
             if (string.IsNullOrEmpty(path))
             {
-                var resultColumns = columns.Where(x => !HasMultipleSegments(x)).ToList();
+                var resultColumns = columns.Where(x => !HasMultipleSegments(x)).Select(x => x.Replace(ODATA_V3_FORMATTING_ESCAPE_SEPARATOR, '/')).ToList();
                 if (excludePaths != null)
                     resultColumns.AddRange(columns.Where(x => HasMultipleSegments(x) &&
                         !excludePaths.Any(y => FormatFirstSegment(y).Contains(FormatFirstSegment(x)))));

--- a/src/Simple.OData.Client.V4.Adapter/CommandFormatter.cs
+++ b/src/Simple.OData.Client.V4.Adapter/CommandFormatter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.OData;
@@ -140,7 +140,7 @@ namespace Simple.OData.Client.V4.Adapter
             return text;
         }
 
-		private const char ODATA_V3_FORMATTING_ESCAPE_SEPARATOR = '~';
+        private const char ODATA_V3_FORMATTING_ESCAPE_SEPARATOR = '~';
 
         private IList<string> SelectPathSegmentColumns(
             IList<string> columns, string path, IList<string> excludePaths = null)


### PR DESCRIPTION
- optimize always-true filters 
- Add support for V3-style select on expanded entities 
- add support for Extra Properties on ODataClientSettings
At this point it is used to allow for Sap B1 services to stringize datetime values
as the service is not allowing proper datetimes but it does accept single-quoted ones
